### PR TITLE
feat: Implement CLI structure with clap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,76 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "skem")]
+#[command(version, about = "A lightweight CLI tool to download specific files from remote Git repositories", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Initialize a new .skem.yaml configuration file
+    Init,
+    /// Output JSON Schema for .skem.yaml configuration
+    Schema,
+    /// Synchronize dependencies (default command)
+    Sync,
+}
+
 fn main() {
-    println!("Hello, skem!");
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Commands::Init) => {
+            println!("Running init command (stub)");
+        }
+        Some(Commands::Schema) => {
+            println!("Running schema command (stub)");
+        }
+        Some(Commands::Sync) | None => {
+            // デフォルトコマンドとして sync を実行
+            println!("Running sync command (stub)");
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
     #[test]
-    fn test_placeholder() {
-        assert_eq!(2 + 2, 4);
+    fn test_cli_verify() {
+        // CLI定義の検証
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn test_default_is_sync() {
+        // 引数なしの場合はSyncコマンドが実行されることを確認
+        let cli = Cli::parse_from(vec!["skem"]);
+        assert!(matches!(cli.command, None));
+    }
+
+    #[test]
+    fn test_init_command_parsing() {
+        // initコマンドのパース確認
+        let cli = Cli::parse_from(vec!["skem", "init"]);
+        assert!(matches!(cli.command, Some(Commands::Init)));
+    }
+
+    #[test]
+    fn test_schema_command_parsing() {
+        // schemaコマンドのパース確認
+        let cli = Cli::parse_from(vec!["skem", "schema"]);
+        assert!(matches!(cli.command, Some(Commands::Schema)));
+    }
+
+    #[test]
+    fn test_sync_command_parsing() {
+        // syncコマンドのパース確認
+        let cli = Cli::parse_from(vec!["skem", "sync"]);
+        assert!(matches!(cli.command, Some(Commands::Sync)));
     }
 }


### PR DESCRIPTION
## Summary
- Implement CLI interface using clap
- Define subcommands: `init`, `schema`, `sync`
- Set `sync` as the default command
- Add help text for each subcommand
- Add unit tests for CLI parsing

## Changes
- `src/main.rs`:
  - Define `Cli` struct and `Commands` enum
  - Each subcommand is currently implemented as a stub
  - Execute `sync` command when no arguments are provided
  - Add 5 unit tests

## Test Results
All tests passed:
- `test_cli_verify`: Verify CLI definition
- `test_default_is_sync`: Verify default command behavior
- `test_init_command_parsing`: Parse init command
- `test_schema_command_parsing`: Parse schema command
- `test_sync_command_parsing`: Parse sync command

## Acceptance Criteria
- ✅ `skem --help` displays help message
- ✅ `skem init --help` and other subcommands display help messages
- ✅ Each subcommand is recognized (implementation can be empty)

## Related
Task2 in plans/implementation-plan.md