### PR TITLE
feat: Implement path stripping and file copying to output directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +433,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]
@@ -502,6 +512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +571,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,31 +18,20 @@ name = "skem"
 path = "src/main.rs"
 
 [dependencies]
-# 非同期ランタイム（軽量化のため rt と macros のみ）
 tokio = { version = "1.42", features = ["rt", "macros", "rt-multi-thread"] }
-
-# CLI フレームワーク
 clap = { version = "4.5", features = ["derive"] }
-
-# シリアライゼーション
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
-
-# JSON Schema 生成
 schemars = "0.8"
-
-# エラーハンドリング
 anyhow = "1.0"
-
-# 一時ディレクトリ
 tempfile = "3.15"
+walkdir = "2.5"
 
 [dev-dependencies]
-# テスト用
 
 [profile.release]
-opt-level = "z"     # サイズ最適化
-lto = true          # Link Time Optimization
-codegen-units = 1   # 最適化を優先
-strip = true        # シンボル削除
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = true

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -1,0 +1,382 @@
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Strip the matching prefix from a file path based on dependency paths
+///
+/// # Arguments
+/// * `file_path` - The absolute file path to process
+/// * `dep_paths` - List of path prefixes to match against
+///
+/// # Returns
+/// The relative path with the matching prefix stripped, or None if no prefix matches
+///
+/// # Example
+/// ```
+/// use std::path::PathBuf;
+/// use skem::copy::strip_path_prefix;
+///
+/// let file_path = PathBuf::from("/tmp/repo/proto/v1/user.proto");
+/// let dep_paths = vec!["proto/v1/".to_string()];
+/// let result = strip_path_prefix(&file_path, &dep_paths);
+/// assert_eq!(result, Some(PathBuf::from("user.proto")));
+/// ```
+pub fn strip_path_prefix(file_path: &Path, dep_paths: &[String]) -> Option<PathBuf> {
+    // Try each dependency path as a potential prefix
+    for dep_path in dep_paths {
+        // Normalize the dep_path to ensure consistent matching
+        let normalized_dep_path = if dep_path.ends_with('/') {
+            dep_path.as_str()
+        } else {
+            // For paths without trailing slash, we'll handle them separately
+            dep_path.as_str()
+        };
+
+        // Convert file_path to string for matching
+        let file_path_str = file_path.to_str()?;
+
+        // Search for the dep_path pattern within the file path
+        if let Some(pos) = file_path_str.find(normalized_dep_path) {
+            // Calculate where to start stripping (after the matched prefix)
+            let strip_start = pos + normalized_dep_path.len();
+
+            // Handle trailing slash: if the dep_path doesn't end with '/',
+            // we need to skip one more character if it's a '/'
+            let strip_start = if !normalized_dep_path.ends_with('/')
+                && file_path_str.chars().nth(strip_start) == Some('/')
+            {
+                strip_start + 1
+            } else {
+                strip_start
+            };
+
+            // Extract the remaining path
+            let stripped = &file_path_str[strip_start..];
+
+            // Return the stripped path if it's not empty
+            if !stripped.is_empty() {
+                return Some(PathBuf::from(stripped));
+            }
+        }
+    }
+
+    // No matching prefix found
+    None
+}
+
+/// Copy files from source directory to output directory with path stripping
+///
+/// # Arguments
+/// * `source_dir` - Source directory containing files (e.g., temp checkout directory)
+/// * `dep_paths` - List of path prefixes to match and strip
+/// * `out_dir` - Output directory where files should be copied
+///
+/// # Returns
+/// Number of files successfully copied
+///
+/// # Example
+/// Copies files matching dep_paths from source_dir to out_dir,
+/// stripping the matching prefix from the destination path.
+pub fn copy_files(source_dir: &Path, dep_paths: &[String], out_dir: &Path) -> Result<usize> {
+    let mut copied_count = 0;
+
+    // Recursively walk through all files in source directory
+    for entry in WalkDir::new(source_dir).into_iter().filter_map(|e| e.ok()) {
+        // Skip directories, only process files
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let file_path = entry.path();
+
+        // Try to strip the prefix from the file path
+        if let Some(stripped_path) = strip_path_prefix(file_path, dep_paths) {
+            // Construct the destination path
+            let dest_path = out_dir.join(&stripped_path);
+
+            // Create parent directories if they don't exist
+            if let Some(parent) = dest_path.parent() {
+                fs::create_dir_all(parent).map_err(|e| {
+                    anyhow::anyhow!("Failed to create parent directory {parent:?}: {e}")
+                })?;
+            }
+
+            // Copy the file to the destination
+            fs::copy(file_path, &dest_path).map_err(|e| {
+                anyhow::anyhow!("Failed to copy file from {file_path:?} to {dest_path:?}: {e}")
+            })?;
+
+            copied_count += 1;
+        }
+    }
+
+    Ok(copied_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_strip_path_prefix_single_level_directory() {
+        // Arrange: File in a single level directory matching the prefix
+        let file_path = PathBuf::from("/tmp/repo/proto/user.proto");
+        let dep_paths = vec!["proto/".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: The "proto/" prefix should be stripped
+        assert_eq!(result, Some(PathBuf::from("user.proto")));
+    }
+
+    #[test]
+    fn test_strip_path_prefix_nested_directory() {
+        // Arrange: File in a nested directory matching the prefix
+        let file_path = PathBuf::from("/tmp/repo/proto/v1/user.proto");
+        let dep_paths = vec!["proto/v1/".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: The "proto/v1/" prefix should be stripped
+        assert_eq!(result, Some(PathBuf::from("user.proto")));
+    }
+
+    #[test]
+    fn test_strip_path_prefix_nested_file_structure() {
+        // Arrange: File with nested structure after the prefix
+        let file_path = PathBuf::from("/tmp/repo/proto/v1/services/auth/user.proto");
+        let dep_paths = vec!["proto/v1/".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: Only "proto/v1/" should be stripped, keeping "services/auth/"
+        assert_eq!(result, Some(PathBuf::from("services/auth/user.proto")));
+    }
+
+    #[test]
+    fn test_strip_path_prefix_multiple_paths_first_match() {
+        // Arrange: Multiple possible prefixes, file matches the first one
+        let file_path = PathBuf::from("/tmp/repo/proto/v1/user.proto");
+        let dep_paths = vec!["proto/v1/".to_string(), "proto/v2/".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: The first matching prefix "proto/v1/" should be stripped
+        assert_eq!(result, Some(PathBuf::from("user.proto")));
+    }
+
+    #[test]
+    fn test_strip_path_prefix_multiple_paths_second_match() {
+        // Arrange: Multiple possible prefixes, file matches the second one
+        let file_path = PathBuf::from("/tmp/repo/proto/v2/user.proto");
+        let dep_paths = vec!["proto/v1/".to_string(), "proto/v2/".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: The second matching prefix "proto/v2/" should be stripped
+        assert_eq!(result, Some(PathBuf::from("user.proto")));
+    }
+
+    #[test]
+    fn test_strip_path_prefix_no_match() {
+        // Arrange: File path that doesn't match any prefix
+        let file_path = PathBuf::from("/tmp/repo/src/main.rs");
+        let dep_paths = vec!["proto/".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: Should return None when no prefix matches
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_strip_path_prefix_empty_paths() {
+        // Arrange: Empty dependency paths list
+        let file_path = PathBuf::from("/tmp/repo/proto/user.proto");
+        let dep_paths: Vec<String> = vec![];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: Should return None when paths list is empty
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_strip_path_prefix_without_trailing_slash() {
+        // Arrange: dep_path without trailing slash
+        let file_path = PathBuf::from("/tmp/repo/proto/user.proto");
+        let dep_paths = vec!["proto".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: Should handle paths without trailing slash
+        assert_eq!(result, Some(PathBuf::from("user.proto")));
+    }
+
+    #[test]
+    fn test_copy_files_single_file() {
+        // Arrange: Create source directory with a single file
+        let source_dir = TempDir::new().expect("Should create temp dir");
+        let proto_dir = source_dir.path().join("proto");
+        fs::create_dir_all(&proto_dir).expect("Should create proto dir");
+        fs::write(proto_dir.join("user.proto"), "message User {}").expect("Should write file");
+
+        let out_dir = TempDir::new().expect("Should create output dir");
+        let dep_paths = vec!["proto/".to_string()];
+
+        // Act: Copy files
+        let count = copy_files(source_dir.path(), &dep_paths, out_dir.path());
+
+        // Assert: File should be copied with stripped path
+        assert!(count.is_ok(), "copy_files should succeed");
+        assert_eq!(count.unwrap(), 1, "Should copy exactly 1 file");
+        assert!(
+            out_dir.path().join("user.proto").exists(),
+            "user.proto should be copied to output directory"
+        );
+
+        let content =
+            fs::read_to_string(out_dir.path().join("user.proto")).expect("Should read copied file");
+        assert_eq!(content, "message User {}");
+    }
+
+    #[test]
+    fn test_copy_files_nested_structure() {
+        // Arrange: Create source directory with nested file structure
+        let source_dir = TempDir::new().expect("Should create temp dir");
+        let nested_dir = source_dir.path().join("proto/v1/services/auth");
+        fs::create_dir_all(&nested_dir).expect("Should create nested dirs");
+        fs::write(nested_dir.join("user.proto"), "message User {}").expect("Should write file");
+
+        let out_dir = TempDir::new().expect("Should create output dir");
+        let dep_paths = vec!["proto/v1/".to_string()];
+
+        // Act: Copy files
+        let count = copy_files(source_dir.path(), &dep_paths, out_dir.path());
+
+        // Assert: File should be copied preserving structure after stripped prefix
+        assert!(count.is_ok(), "copy_files should succeed");
+        assert_eq!(count.unwrap(), 1, "Should copy exactly 1 file");
+        assert!(
+            out_dir.path().join("services/auth/user.proto").exists(),
+            "File should be copied with nested structure preserved"
+        );
+    }
+
+    #[test]
+    fn test_copy_files_multiple_files() {
+        // Arrange: Create source directory with multiple files
+        let source_dir = TempDir::new().expect("Should create temp dir");
+        let proto_dir = source_dir.path().join("proto");
+        fs::create_dir_all(&proto_dir).expect("Should create proto dir");
+        fs::write(proto_dir.join("user.proto"), "message User {}").expect("Should write file");
+        fs::write(proto_dir.join("post.proto"), "message Post {}").expect("Should write file");
+
+        let out_dir = TempDir::new().expect("Should create output dir");
+        let dep_paths = vec!["proto/".to_string()];
+
+        // Act: Copy files
+        let count = copy_files(source_dir.path(), &dep_paths, out_dir.path());
+
+        // Assert: All files should be copied
+        assert!(count.is_ok(), "copy_files should succeed");
+        assert_eq!(count.unwrap(), 2, "Should copy exactly 2 files");
+        assert!(
+            out_dir.path().join("user.proto").exists(),
+            "user.proto should exist"
+        );
+        assert!(
+            out_dir.path().join("post.proto").exists(),
+            "post.proto should exist"
+        );
+    }
+
+    #[test]
+    fn test_copy_files_creates_parent_directories() {
+        // Arrange: Create source directory with deeply nested file
+        let source_dir = TempDir::new().expect("Should create temp dir");
+        let nested_dir = source_dir.path().join("proto/v1/a/b/c");
+        fs::create_dir_all(&nested_dir).expect("Should create nested dirs");
+        fs::write(nested_dir.join("deep.proto"), "message Deep {}").expect("Should write file");
+
+        let out_dir = TempDir::new().expect("Should create output dir");
+        let dep_paths = vec!["proto/v1/".to_string()];
+
+        // Act: Copy files
+        let count = copy_files(source_dir.path(), &dep_paths, out_dir.path());
+
+        // Assert: Parent directories should be created automatically
+        assert!(count.is_ok(), "copy_files should succeed");
+        assert_eq!(count.unwrap(), 1, "Should copy exactly 1 file");
+        assert!(
+            out_dir.path().join("a/b/c/deep.proto").exists(),
+            "File should be copied with all parent directories created"
+        );
+    }
+
+    #[test]
+    fn test_copy_files_no_matching_files() {
+        // Arrange: Create source directory with files that don't match dep_paths
+        let source_dir = TempDir::new().expect("Should create temp dir");
+        let src_dir = source_dir.path().join("src");
+        fs::create_dir_all(&src_dir).expect("Should create src dir");
+        fs::write(src_dir.join("main.rs"), "fn main() {}").expect("Should write file");
+
+        let out_dir = TempDir::new().expect("Should create output dir");
+        let dep_paths = vec!["proto/".to_string()]; // Looking for proto, but only src exists
+
+        // Act: Copy files
+        let count = copy_files(source_dir.path(), &dep_paths, out_dir.path());
+
+        // Assert: No files should be copied
+        assert!(count.is_ok(), "copy_files should succeed");
+        assert_eq!(count.unwrap(), 0, "Should copy 0 files when no matches");
+    }
+
+    #[test]
+    fn test_copy_files_multiple_dep_paths() {
+        // Arrange: Create source directory with files in different paths
+        let source_dir = TempDir::new().expect("Should create temp dir");
+
+        let proto_v1_dir = source_dir.path().join("proto/v1");
+        fs::create_dir_all(&proto_v1_dir).expect("Should create proto/v1 dir");
+        fs::write(proto_v1_dir.join("user.proto"), "message User {}").expect("Should write file");
+
+        let proto_v2_dir = source_dir.path().join("proto/v2");
+        fs::create_dir_all(&proto_v2_dir).expect("Should create proto/v2 dir");
+        fs::write(proto_v2_dir.join("post.proto"), "message Post {}").expect("Should write file");
+
+        let out_dir = TempDir::new().expect("Should create output dir");
+        let dep_paths = vec!["proto/v1/".to_string(), "proto/v2/".to_string()];
+
+        // Act: Copy files
+        let count = copy_files(source_dir.path(), &dep_paths, out_dir.path());
+
+        // Assert: Files from both paths should be copied
+        assert!(count.is_ok(), "copy_files should succeed");
+        assert_eq!(
+            count.unwrap(),
+            2,
+            "Should copy 2 files from different paths"
+        );
+        assert!(
+            out_dir.path().join("user.proto").exists(),
+            "user.proto from v1 should exist"
+        );
+        assert!(
+            out_dir.path().join("post.proto").exists(),
+            "post.proto from v2 should exist"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod change_detection;
 pub mod config;
+pub mod copy;
 pub mod fetch;
 pub mod git;
 pub mod init;


### PR DESCRIPTION
## Summary

Implements path stripping and file copying functionality to enable copying files from temporary checkout directories to output directories with intelligent prefix removal.

## What Changed

- **`strip_path_prefix` function**: Matches and removes path prefixes from file paths based on dependency configuration
- **`copy_files` function**: Recursively walks through source directory, applies path stripping, and copies files to output directory
- **Automatic directory creation**: Parent directories are created automatically during file copying
- **Multiple path support**: Handles multiple dependency paths with flexible prefix matching (with or without trailing slashes)
- **`walkdir` dependency**: Added for efficient recursive directory traversal

## Why These Changes

These changes complete the core file synchronization pipeline:
1. Fetch files using sparse checkout (previous task)
2. **[NEW] Strip paths and copy files to output** ← This PR
3. Execute hooks and update lockfile (next tasks)

This functionality bridges between raw Git sparse checkout results and user-configured output directory structure.

## Testing

- **8 path stripping tests**: Single/nested directories, multiple paths, edge cases with/without trailing slashes
- **6 file copying tests**: Single/multiple files, nested structures, directory creation, multiple dependency paths
- **Total test coverage**: 14 new tests, all passing
- **Code quality**: All clippy and rustfmt checks passing

## Technical Details

- Uses `WalkDir` for efficient directory traversal
- Path matching is done via string prefix search
- File copying uses standard `fs::copy` with proper error handling
- All operations properly handle both absolute and relative paths