### PR TITLE
feat: Add interactive mode for add command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -60,9 +60,21 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -117,6 +129,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -149,6 +186,24 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "getrandom"
@@ -203,6 +258,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +326,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +357,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "prettyplease"
@@ -291,16 +416,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -341,6 +475,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -416,11 +556,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "skem"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "inquire",
  "schemars",
  "serde",
  "serde_json",
@@ -428,6 +600,12 @@ dependencies = [
  "tempfile",
  "walkdir",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -456,7 +634,16 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -464,6 +651,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -492,6 +691,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -539,11 +744,27 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -551,8 +772,14 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -562,12 +789,78 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "wit-bindgen"
@@ -627,7 +920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_yaml = "0.9"
 serde_json = "1.0"
 schemars = "0.8"
 anyhow = "1.0"
+inquire = "0.7"
 tempfile = "3.15"
 walkdir = "2.5"
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -83,6 +83,61 @@ impl GitCommand {
         Ok(())
     }
 
+    /// Execute `git clone --depth 1 --filter=blob:none --no-checkout <repo> <path>`
+    ///
+    /// Clones a repository without checking out any files,
+    /// fetching only tree objects (no blobs).
+    ///
+    /// # Arguments
+    /// * `repo` - Repository URL
+    /// * `path` - Destination path
+    pub fn clone_blobless(repo: &str, path: &Path) -> Result<()> {
+        let output = Command::new("git")
+            .arg("clone")
+            .arg("--depth")
+            .arg("1")
+            .arg("--filter=blob:none")
+            .arg("--no-checkout")
+            .arg(repo)
+            .arg(path)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git clone (blobless) failed: {stderr}");
+        }
+
+        Ok(())
+    }
+
+    /// Execute `git ls-tree -r --name-only <rev>` to list files in the repository
+    ///
+    /// # Arguments
+    /// * `repo_path` - Path to the cloned repository
+    /// * `rev` - Revision to list files from
+    ///
+    /// # Returns
+    /// A list of file paths in the repository
+    pub fn ls_tree(repo_path: &Path, rev: &str) -> Result<Vec<String>> {
+        let output = Command::new("git")
+            .arg("ls-tree")
+            .arg("-r")
+            .arg("--name-only")
+            .arg(rev)
+            .current_dir(repo_path)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git ls-tree failed: {stderr}");
+        }
+
+        let stdout = String::from_utf8(output.stdout)?;
+        let paths: Vec<String> = stdout.lines().map(|l| l.to_string()).collect();
+
+        Ok(paths)
+    }
+
     /// Execute `git checkout <rev>` in the specified repository
     ///
     /// # Arguments
@@ -194,6 +249,51 @@ mod tests {
         let result = GitCommand::checkout(&repo_path, "HEAD");
 
         assert!(result.is_ok(), "checkout HEAD should succeed: {result:?}");
+    }
+
+    #[test]
+    fn test_clone_blobless_creates_git_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let clone_path = temp_dir.path().join("test_repo");
+
+        let result = GitCommand::clone_blobless(TEST_REPO, &clone_path);
+
+        assert!(result.is_ok(), "clone_blobless should succeed: {result:?}");
+        assert!(clone_path.exists(), "Cloned directory should exist");
+        assert!(
+            clone_path.join(".git").exists(),
+            ".git directory should exist"
+        );
+    }
+
+    #[test]
+    fn test_ls_tree_returns_file_paths() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_path = temp_dir.path().join("test_repo");
+
+        GitCommand::clone_blobless(TEST_REPO, &repo_path).unwrap();
+
+        let result = GitCommand::ls_tree(&repo_path, "HEAD");
+
+        assert!(result.is_ok(), "ls_tree should succeed: {result:?}");
+        let files = result.unwrap();
+        assert!(!files.is_empty(), "Should return at least one file");
+        assert!(
+            files.iter().any(|f| f.contains("Cargo.toml")),
+            "Should contain Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn test_ls_tree_invalid_rev() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_path = temp_dir.path().join("test_repo");
+
+        GitCommand::clone_blobless(TEST_REPO, &repo_path).unwrap();
+
+        let result = GitCommand::ls_tree(&repo_path, "nonexistent-revision-xyz");
+
+        assert!(result.is_err(), "ls_tree should fail for invalid revision");
     }
 
     #[test]

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,0 +1,201 @@
+use crate::add;
+use crate::git::GitCommand;
+use anyhow::Result;
+use inquire::{MultiSelect, Text};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Collect directory and file entries from a list of file paths.
+///
+/// Extracts all parent directories (with trailing `/`) and includes
+/// original file paths. Results are sorted and deduplicated.
+///
+/// # Arguments
+/// * `file_paths` - List of file paths from `git ls-tree`
+///
+/// # Returns
+/// A sorted list of directory and file entries
+pub fn collect_entries(file_paths: &[String]) -> Vec<String> {
+    let mut entries = BTreeSet::new();
+
+    for path in file_paths {
+        entries.insert(path.clone());
+
+        // Extract all parent directories
+        let mut current = path.as_str();
+        while let Some(pos) = current.rfind('/') {
+            let dir = &current[..=pos];
+            if !entries.insert(dir.to_string()) {
+                // Already seen this directory, all parents are also already inserted
+                break;
+            }
+            current = &current[..pos];
+        }
+    }
+
+    entries.into_iter().collect()
+}
+
+/// List all entries (directories and files) in a remote repository.
+///
+/// Clones the repository in blobless mode and runs `ls-tree` to get file paths,
+/// then expands them into directory + file entries.
+///
+/// # Arguments
+/// * `repo` - Repository URL
+/// * `rev` - Revision to list (e.g. "HEAD", "main", tag)
+///
+/// # Returns
+/// A sorted list of directory and file entries
+pub fn list_repo_entries(repo: &str, rev: &str) -> Result<Vec<String>> {
+    let temp_dir = tempfile::tempdir()?;
+    let repo_path = temp_dir.path().join("repo");
+
+    eprintln!("Cloning repository...");
+    GitCommand::clone_blobless(repo, &repo_path)?;
+
+    eprintln!("Fetching file tree...");
+    let file_paths = GitCommand::ls_tree(&repo_path, rev)?;
+
+    Ok(collect_entries(&file_paths))
+}
+
+/// Prompt the user to select paths using fuzzy multi-select.
+///
+/// # Arguments
+/// * `entries` - List of available entries (directories and files)
+///
+/// # Returns
+/// The selected entries
+pub fn prompt_select_paths(entries: &[String]) -> Result<Vec<String>> {
+    let selected = MultiSelect::new("Select paths to include:", entries.to_vec())
+        .with_help_message("Type to filter, <space> to toggle, <enter> to confirm")
+        .prompt()?;
+
+    if selected.is_empty() {
+        anyhow::bail!("No paths selected.");
+    }
+
+    Ok(selected)
+}
+
+/// Prompt the user for an output directory.
+///
+/// # Arguments
+/// * `default` - Default value for the output directory
+///
+/// # Returns
+/// The output directory path
+pub fn prompt_output_dir(default: &str) -> Result<String> {
+    let output = Text::new("Output directory:")
+        .with_default(default)
+        .prompt()?;
+
+    Ok(output)
+}
+
+/// Run the interactive add workflow.
+///
+/// 1. Clone the repository in blobless mode
+/// 2. List all entries (directories + files)
+/// 3. Prompt user to select paths
+/// 4. Prompt user for output directory
+/// 5. Delegate to `add::run_add`
+///
+/// # Arguments
+/// * `config_path` - Path to the config file
+/// * `repo` - Git repository URL
+/// * `rev` - Optional revision
+/// * `name` - Optional dependency name
+pub fn run_interactive_add(
+    config_path: &Path,
+    repo: &str,
+    rev: Option<&str>,
+    name: Option<&str>,
+) -> Result<()> {
+    let rev_str = rev.unwrap_or("HEAD");
+    let entries = list_repo_entries(repo, rev_str)?;
+
+    if entries.is_empty() {
+        anyhow::bail!("No files found in the repository.");
+    }
+
+    let selected_paths = prompt_select_paths(&entries)?;
+
+    let repo_name = add::extract_repo_name(repo)?;
+    let default_out = format!("./vendor/{repo_name}");
+    let out = prompt_output_dir(&default_out)?;
+
+    add::run_add(config_path, repo, selected_paths, &out, name, rev)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collect_entries_basic() {
+        let file_paths = vec![
+            "proto/v1/user.proto".to_string(),
+            "proto/v1/order.proto".to_string(),
+            "README.md".to_string(),
+        ];
+
+        let result = collect_entries(&file_paths);
+
+        let expected = vec![
+            "README.md",
+            "proto/",
+            "proto/v1/",
+            "proto/v1/order.proto",
+            "proto/v1/user.proto",
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_collect_entries_empty() {
+        let file_paths: Vec<String> = vec![];
+
+        let result = collect_entries(&file_paths);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_collect_entries_root_files() {
+        let file_paths = vec![
+            "LICENSE".to_string(),
+            "README.md".to_string(),
+            "Cargo.toml".to_string(),
+        ];
+
+        let result = collect_entries(&file_paths);
+
+        let expected = vec!["Cargo.toml", "LICENSE", "README.md"];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_collect_entries_nested() {
+        let file_paths = vec![
+            "a/b/c/d.txt".to_string(),
+            "a/b/e.txt".to_string(),
+            "a/f.txt".to_string(),
+        ];
+
+        let result = collect_entries(&file_paths);
+
+        let expected = vec![
+            "a/",
+            "a/b/",
+            "a/b/c/",
+            "a/b/c/d.txt",
+            "a/b/e.txt",
+            "a/f.txt",
+        ];
+        assert_eq!(result, expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod fetch;
 pub mod git;
 pub mod hooks;
 pub mod init;
+pub mod interactive;
 pub mod lockfile;
 pub mod ls;
 pub mod rm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use skem::{add, check, config, init, ls, rm, schema, sync};
+use skem::{add, check, config, init, interactive, ls, rm, schema, sync};
 use std::path::Path;
 
 #[derive(Parser)]
@@ -23,12 +23,12 @@ enum Commands {
         /// Git repository URL
         #[arg(long)]
         repo: String,
-        /// Paths to download from the repository
+        /// Paths to download from the repository (omit for interactive mode)
         #[arg(long, num_args = 1..)]
-        paths: Vec<String>,
-        /// Output directory
+        paths: Option<Vec<String>>,
+        /// Output directory (omit for interactive mode)
         #[arg(long)]
-        out: String,
+        out: Option<String>,
         /// Dependency name (defaults to repository name)
         #[arg(long)]
         name: Option<String>,
@@ -60,14 +60,26 @@ fn main() {
             out,
             name,
             rev,
-        }) => add::run_add(
-            Path::new(config::CONFIG_PATH),
-            &repo,
-            paths,
-            &out,
-            name.as_deref(),
-            rev.as_deref(),
-        ),
+        }) => match (paths, out) {
+            (Some(paths), Some(out)) => add::run_add(
+                Path::new(config::CONFIG_PATH),
+                &repo,
+                paths,
+                &out,
+                name.as_deref(),
+                rev.as_deref(),
+            ),
+            (None, None) => interactive::run_interactive_add(
+                Path::new(config::CONFIG_PATH),
+                &repo,
+                rev.as_deref(),
+                name.as_deref(),
+            ),
+            _ => {
+                eprintln!("Error: --paths and --out must be specified together, or both omitted for interactive mode.");
+                std::process::exit(1);
+            }
+        },
         Some(Commands::Rm { name }) => rm::run_rm_default(&name),
         Some(Commands::Ls) => ls::run_ls_default(),
         Some(Commands::Check) => match check::run_check_default() {
@@ -163,10 +175,40 @@ mod tests {
                 rev,
             }) => {
                 assert_eq!(repo, "https://github.com/example/api.git");
-                assert_eq!(paths, vec!["proto/", "openapi/"]);
-                assert_eq!(out, "./vendor/api");
+                assert_eq!(
+                    paths,
+                    Some(vec!["proto/".to_string(), "openapi/".to_string()])
+                );
+                assert_eq!(out, Some("./vendor/api".to_string()));
                 assert_eq!(name, Some("my-api".to_string()));
                 assert_eq!(rev, Some("v2.0".to_string()));
+            }
+            _ => panic!("Expected Add command"),
+        }
+    }
+
+    #[test]
+    fn test_add_command_parsing_interactive_mode() {
+        // --paths and --out omitted for interactive mode
+        let cli = Cli::parse_from(vec![
+            "skem",
+            "add",
+            "--repo",
+            "https://github.com/example/api.git",
+        ]);
+        match cli.command {
+            Some(Commands::Add {
+                repo,
+                paths,
+                out,
+                name,
+                rev,
+            }) => {
+                assert_eq!(repo, "https://github.com/example/api.git");
+                assert_eq!(paths, None);
+                assert_eq!(out, None);
+                assert_eq!(name, None);
+                assert_eq!(rev, None);
             }
             _ => panic!("Expected Add command"),
         }


### PR DESCRIPTION
## Summary

Add an interactive mode to `skem add` when `--paths` and `--out` are omitted. The user can fuzzy-search the remote repository's file tree and select paths interactively.

## Changes

- Add `clone_blobless` / `ls_tree` methods to `GitCommand` for fast file tree retrieval via blobless clone
- Create `interactive` module
  - `collect_entries`: Generate directory (trailing `/`) and file entries from file path list
  - `list_repo_entries`: Combine clone + ls-tree + collect_entries
  - `prompt_select_paths` / `prompt_output_dir`: Fuzzy multi-select and text input via `inquire`
  - `run_interactive_add`: Orchestrate the full interactive flow
- Make `--paths` / `--out` optional in the `add` command, routing to interactive mode when both are omitted
- Add `inquire` crate dependency

## Behavior

| `--paths` | `--out` | Behavior |
|---|---|---|
| provided | provided | Non-interactive (existing behavior) |
| omitted | omitted | Interactive mode |
| only one | - | Error |