### PR TITLE
feat: Add config validation for check and sync commands

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -1,6 +1,7 @@
 use crate::config::{self, Dependency, Lockfile};
 use crate::git::GitCommand;
 use crate::lockfile;
+use crate::validate::validate_config;
 use anyhow::Result;
 use std::path::Path;
 
@@ -55,6 +56,7 @@ pub fn check_dependency(dep: &Dependency, lockfile: &Lockfile) -> Result<CheckRe
 /// true if all dependencies are up to date, false otherwise
 pub fn run_check(config_path: &Path, lockfile_path: &Path) -> Result<bool> {
     let config = config::read_config(config_path)?;
+    validate_config(&config)?;
 
     if config.deps.is_empty() {
         println!("No dependencies to check.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod ls;
 pub mod rm;
 pub mod schema;
 pub mod sync;
+pub mod validate;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,6 +4,7 @@ use crate::fetch::fetch_files;
 use crate::git::GitCommand;
 use crate::hooks::execute_hooks;
 use crate::lockfile;
+use crate::validate::validate_config;
 use anyhow::Result;
 use std::path::Path;
 
@@ -101,6 +102,7 @@ pub fn sync_dependencies(
 pub fn run_sync() -> Result<()> {
     let config_path = Path::new(config::CONFIG_PATH);
     let config = config::read_config(config_path)?;
+    validate_config(&config)?;
 
     if config.deps.is_empty() {
         println!("No dependencies to synchronize.");

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,0 +1,210 @@
+use crate::config::Config;
+use anyhow::{bail, Result};
+use std::collections::HashSet;
+
+/// Validate a Config for semantic correctness
+pub fn validate_config(config: &Config) -> Result<()> {
+    // Validate each dependency field
+    for (i, dep) in config.deps.iter().enumerate() {
+        if dep.name.is_empty() {
+            bail!("deps[{i}]: name must not be empty");
+        }
+        if dep.repo.is_empty() {
+            bail!("deps[{i}] ({}): repo must not be empty", dep.name);
+        }
+        if dep.paths.is_empty() {
+            bail!("deps[{i}] ({}): paths must not be empty", dep.name);
+        }
+        if dep.out.is_empty() {
+            bail!("deps[{i}] ({}): out must not be empty", dep.name);
+        }
+    }
+
+    // Check for duplicate dependency names
+    let mut seen_names = HashSet::new();
+    for dep in &config.deps {
+        if !seen_names.insert(&dep.name) {
+            bail!("duplicate dependency name: {}", dep.name);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, Dependency};
+
+    #[test]
+    fn test_validate_config_valid() {
+        let config = Config {
+            deps: vec![Dependency {
+                name: "dep1".to_string(),
+                repo: "https://github.com/example/repo.git".to_string(),
+                rev: Some("main".to_string()),
+                paths: vec!["src/".to_string()],
+                out: "./vendor/dep1".to_string(),
+                hooks: vec![],
+            }],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_empty_deps_is_valid() {
+        let config = Config {
+            deps: vec![],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_duplicate_names() {
+        let config = Config {
+            deps: vec![
+                Dependency {
+                    name: "dep1".to_string(),
+                    repo: "https://github.com/example/repo1.git".to_string(),
+                    rev: None,
+                    paths: vec!["src/".to_string()],
+                    out: "./vendor/dep1".to_string(),
+                    hooks: vec![],
+                },
+                Dependency {
+                    name: "dep1".to_string(),
+                    repo: "https://github.com/example/repo2.git".to_string(),
+                    rev: None,
+                    paths: vec!["lib/".to_string()],
+                    out: "./vendor/dep2".to_string(),
+                    hooks: vec![],
+                },
+            ],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("dep1"),
+            "error should mention the duplicate name: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_config_empty_name() {
+        let config = Config {
+            deps: vec![Dependency {
+                name: "".to_string(),
+                repo: "https://github.com/example/repo.git".to_string(),
+                rev: None,
+                paths: vec!["src/".to_string()],
+                out: "./vendor/dep1".to_string(),
+                hooks: vec![],
+            }],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("name"),
+            "error should mention 'name': {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_config_empty_repo() {
+        let config = Config {
+            deps: vec![Dependency {
+                name: "dep1".to_string(),
+                repo: "".to_string(),
+                rev: None,
+                paths: vec!["src/".to_string()],
+                out: "./vendor/dep1".to_string(),
+                hooks: vec![],
+            }],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("repo"),
+            "error should mention 'repo': {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_config_empty_paths() {
+        let config = Config {
+            deps: vec![Dependency {
+                name: "dep1".to_string(),
+                repo: "https://github.com/example/repo.git".to_string(),
+                rev: None,
+                paths: vec![],
+                out: "./vendor/dep1".to_string(),
+                hooks: vec![],
+            }],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("paths"),
+            "error should mention 'paths': {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_config_empty_out() {
+        let config = Config {
+            deps: vec![Dependency {
+                name: "dep1".to_string(),
+                repo: "https://github.com/example/repo.git".to_string(),
+                rev: None,
+                paths: vec!["src/".to_string()],
+                out: "".to_string(),
+                hooks: vec![],
+            }],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("out"),
+            "error should mention 'out': {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_config_multiple_errors_reports_first() {
+        let config = Config {
+            deps: vec![Dependency {
+                name: "".to_string(),
+                repo: "".to_string(),
+                rev: None,
+                paths: vec![],
+                out: "".to_string(),
+                hooks: vec![],
+            }],
+            post_hooks: vec![],
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `validate` module with semantic validation for `Config`
- Validates that each dependency's `name`, `repo`, `paths`, and `out` fields are non-empty
- Detects duplicate dependency names
- Calls `validate_config()` in both `check` and `sync` commands right after reading config

## Test plan
- [x] Unit tests for all validation rules (8 tests in `validate::tests`)
- [x] `cargo test` — all 110 tests pass
- [x] `cargo clippy --all-targets --all-features` — no warnings
- [x] `cargo fmt --all --check` — formatted