### PR TITLE
docs: Fix environment variable passing in install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ curl -fsSL https://raw.githubusercontent.com/hiro-o918/skem/main/install.sh | ba
 You can also specify a version or install directory:
 
 ```bash
-VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/hiro-o918/skem/main/install.sh | bash
-INSTALL_DIR=~/.local/bin curl -fsSL https://raw.githubusercontent.com/hiro-o918/skem/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/hiro-o918/skem/main/install.sh | VERSION=v0.1.0 bash
+curl -fsSL https://raw.githubusercontent.com/hiro-o918/skem/main/install.sh | INSTALL_DIR=~/.local/bin bash
 ```
 
 ### From source


### PR DESCRIPTION
## Summary
- Fix environment variable placement in install script examples in README
- `VERSION=v0.1.0 curl ... | bash` passes the variable only to `curl`, not to `bash` via the pipe
- Changed to `curl ... | VERSION=v0.1.0 bash` so that variables are correctly passed to the install script

## Test plan
- [ ] Verify `curl -fsSL ... | VERSION=v0.1.0 bash` correctly installs the specified version
- [ ] Verify `curl -fsSL ... | INSTALL_DIR=/tmp/skem-test bash` correctly installs to the specified directory