### PR TITLE
chore: Add Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,7 @@
     enabled: true,
   },
   extends: ["config:base"],
-  enabledManagers: ["cargo"],
+  enabledManagers: ["cargo", "github-actions"],
   automerge: false,
   packageRules: [
     {
@@ -17,6 +17,19 @@
     {
       groupName: "rust minor-major dependencies",
       matchManagers: ["cargo"],
+      matchUpdateTypes: ["minor", "major"],
+      matchPackagePatterns: ["*"],
+    },
+    {
+      groupName: "github-actions patch dependencies",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["patch"],
+      matchPackagePatterns: ["*"],
+      automerge: true,
+    },
+    {
+      groupName: "github-actions minor-major dependencies",
+      matchManagers: ["github-actions"],
       matchUpdateTypes: ["minor", "major"],
       matchPackagePatterns: ["*"],
     },


### PR DESCRIPTION
## Summary
- Add Renovate configuration for automated dependency updates
- Enable `cargo` and `github-actions` managers
- Auto-merge patch updates for both Rust dependencies and GitHub Actions
- Group minor/major updates for manual review

## Test plan
- [ ] Verify Renovate picks up the configuration and creates dependency update PRs
- [ ] Confirm patch updates are auto-merged
- [ ] Confirm minor/major updates require manual approval