### PR TITLE
fix: support file paths in sparse-checkout and copy

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -55,10 +55,10 @@ pub fn strip_path_prefix(file_path: &Path, dep_paths: &[String]) -> Option<PathB
             let stripped = &file_path_str[strip_start..];
 
             if !stripped.is_empty() {
-                // ディレクトリ指定の場合: stripped にサブパスが残る
+                // Directory match: remaining subpath after the prefix
                 return Some(PathBuf::from(stripped));
             } else {
-                // ファイル指定の場合: dep_path がファイル名まで含む → ファイル名を返す
+                // File match: dep_path includes the filename itself, so return the filename
                 let file_name = Path::new(normalized_dep_path).file_name()?;
                 return Some(PathBuf::from(file_name));
             }
@@ -229,6 +229,32 @@ mod tests {
     }
 
     #[test]
+    fn test_strip_path_prefix_exact_file_path() {
+        // Arrange: dep_path points directly to a file (not a directory)
+        let file_path = PathBuf::from("/tmp/repo/backend/api/openapi3.yaml");
+        let dep_paths = vec!["backend/api/openapi3.yaml".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: Should return just the filename when dep_path is an exact file path
+        assert_eq!(result, Some(PathBuf::from("openapi3.yaml")));
+    }
+
+    #[test]
+    fn test_strip_path_prefix_exact_file_path_nested() {
+        // Arrange: dep_path points directly to a deeply nested file
+        let file_path = PathBuf::from("/tmp/repo/backend/apiapp/gen/http/openapi3.yaml");
+        let dep_paths = vec!["backend/apiapp/gen/http/openapi3.yaml".to_string()];
+
+        // Act: Strip the prefix
+        let result = strip_path_prefix(&file_path, &dep_paths);
+
+        // Assert: Should return just the filename
+        assert_eq!(result, Some(PathBuf::from("openapi3.yaml")));
+    }
+
+    #[test]
     fn test_copy_files_single_file() {
         // Arrange: Create source directory with a single file
         let source_dir = TempDir::new().expect("Should create temp dir");
@@ -347,6 +373,34 @@ mod tests {
             copied_files.is_empty(),
             "Should copy 0 files when no matches"
         );
+    }
+
+    #[test]
+    fn test_copy_files_exact_file_path() {
+        // Arrange: Create source directory with a file specified by exact path in dep_paths
+        let source_dir = TempDir::new().expect("Should create temp dir");
+        let nested_dir = source_dir.path().join("backend/api");
+        fs::create_dir_all(&nested_dir).expect("Should create nested dirs");
+        fs::write(nested_dir.join("openapi3.yaml"), "openapi: 3.0.0").expect("Should write file");
+
+        let out_dir = TempDir::new().expect("Should create output dir");
+        let dep_paths = vec!["backend/api/openapi3.yaml".to_string()];
+
+        // Act: Copy files
+        let result = copy_files(source_dir.path(), &dep_paths, out_dir.path());
+
+        // Assert: File should be copied with just the filename (no path prefix)
+        assert!(result.is_ok(), "copy_files should succeed");
+        let copied_files = result.unwrap();
+        let expected = vec![out_dir.path().join("openapi3.yaml")];
+        assert_eq!(copied_files, expected);
+        assert!(
+            out_dir.path().join("openapi3.yaml").exists(),
+            "openapi3.yaml should be copied to output directory"
+        );
+        let content = fs::read_to_string(out_dir.path().join("openapi3.yaml"))
+            .expect("Should read copied file");
+        assert_eq!(content, "openapi: 3.0.0");
     }
 
     #[test]

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -54,9 +54,13 @@ pub fn strip_path_prefix(file_path: &Path, dep_paths: &[String]) -> Option<PathB
             // Extract the remaining path
             let stripped = &file_path_str[strip_start..];
 
-            // Return the stripped path if it's not empty
             if !stripped.is_empty() {
+                // ディレクトリ指定の場合: stripped にサブパスが残る
                 return Some(PathBuf::from(stripped));
+            } else {
+                // ファイル指定の場合: dep_path がファイル名まで含む → ファイル名を返す
+                let file_name = Path::new(normalized_dep_path).file_name()?;
+                return Some(PathBuf::from(file_name));
             }
         }
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -67,7 +67,7 @@ impl GitCommand {
     /// * `paths` - Paths to checkout
     pub fn sparse_checkout_set(repo_path: &Path, paths: &[String]) -> Result<()> {
         let mut cmd = Command::new("git");
-        cmd.arg("sparse-checkout").arg("set");
+        cmd.arg("sparse-checkout").arg("set").arg("--skip-checks");
 
         for path in paths {
             cmd.arg(path);


### PR DESCRIPTION
## Summary

- Fixed an issue where specifying a file path (e.g., `backend/apiapp/gen/http/openapi3.yaml`) in `paths` did not work
- Previously only directory-level paths were supported; this change allows fetching specific files

## Changes

- **`src/git.rs`**: Add `--skip-checks` to `git sparse-checkout set`
  - Git rejects file path specifications by default; this flag bypasses that restriction
- **`src/copy.rs`**: Fix `strip_path_prefix` to handle the case where `stripped` is empty after matching
  - When a file is specified directly (i.e., `dep_path` includes the filename), `stripped` becomes empty
  - In this case, return the filename from `dep_path` instead

## Tests

- `test_strip_path_prefix_exact_file_path`: verifies correct behavior when `dep_path` points directly to a file
- `test_strip_path_prefix_exact_file_path_nested`: verifies the same for deeply nested file paths
- `test_copy_files_exact_file_path`: end-to-end test for copying a file specified by exact path