### PR TITLE
feat: add `skem llms` subcommand for LLM agents

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,3 +73,12 @@ Outputs JSON Schema for `.skem.yaml` configuration file, useful for editor compl
 ```bash
 skem schema
 ```
+
+## `skem llms`
+
+Prints a self-contained English usage guide aimed at LLM agents. Pipe it into an agent's context (for example, an `AGENTS.md`-style file) so the agent can drive `skem` without needing to read this repository.
+
+```bash
+skem llms
+skem llms > AGENTS.skem.md
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod git;
 pub mod hooks;
 pub mod init;
 pub mod interactive;
+pub mod llms;
 pub mod lockfile;
 pub mod ls;
 pub mod rm;

--- a/src/llms.rs
+++ b/src/llms.rs
@@ -1,0 +1,118 @@
+use anyhow::Result;
+
+/// Static, English, LLM-oriented usage guide for skem.
+///
+/// The text is intentionally self-contained so that an LLM agent can
+/// understand how to use skem from a single `skem llms` invocation,
+/// without needing to fetch the README or the docs directory.
+pub const GUIDE: &str = include_str!("llms_guide.md");
+
+/// Return the guide content. Kept as a function so future variants
+/// (filtered/short forms) can be added without changing call sites.
+pub fn guide() -> &'static str {
+    GUIDE
+}
+
+/// Print the guide to stdout.
+pub fn run() -> Result<()> {
+    println!("{}", guide());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_guide_is_not_empty() {
+        let text = guide();
+        assert!(!text.is_empty());
+    }
+
+    #[test]
+    fn test_guide_documents_all_subcommands() {
+        let text = guide();
+        for cmd in [
+            "skem init",
+            "skem schema",
+            "skem sync",
+            "skem add",
+            "skem rm",
+            "skem ls",
+            "skem check",
+            "skem self-update",
+            "skem llms",
+        ] {
+            assert!(
+                text.contains(cmd),
+                "guide should mention `{cmd}` but did not"
+            );
+        }
+    }
+
+    #[test]
+    fn test_guide_documents_config_file_format() {
+        let text = guide();
+        assert!(text.contains(".skem.yaml"));
+        assert!(text.contains(".skem.lock"));
+        for field in [
+            "deps:",
+            "name:",
+            "repo:",
+            "paths:",
+            "out:",
+            "rev:",
+            "hooks:",
+            "post_hooks:",
+        ] {
+            assert!(
+                text.contains(field),
+                "guide should document config field `{field}` but did not"
+            );
+        }
+    }
+
+    #[test]
+    fn test_guide_documents_hook_environment_variable() {
+        let text = guide();
+        assert!(
+            text.contains("SKEM_SYNCED_FILES"),
+            "guide should document the SKEM_SYNCED_FILES env var available to hooks"
+        );
+    }
+
+    #[test]
+    fn test_guide_documents_sync_flags() {
+        let text = guide();
+        assert!(text.contains("--force"));
+        assert!(text.contains("--hooks-only"));
+    }
+
+    #[test]
+    fn test_guide_documents_add_interactive_mode() {
+        let text = guide();
+        assert!(text.to_lowercase().contains("interactive"));
+        assert!(text.contains("--paths"));
+        assert!(text.contains("--out"));
+        assert!(text.contains("--repo"));
+    }
+
+    #[test]
+    fn test_guide_mentions_exit_code_semantics_for_check() {
+        let text = guide();
+        assert!(text.contains("check"));
+        assert!(
+            text.contains("exit") || text.contains("Exit"),
+            "guide should describe `skem check` exit code behavior"
+        );
+    }
+
+    #[test]
+    fn test_run_writes_guide_without_error() {
+        // run() prints to stdout; just verify it returns Ok and the
+        // underlying guide content is non-empty.
+        let result = run();
+        assert!(result.is_ok());
+        assert!(!guide().is_empty());
+    }
+}

--- a/src/llms_guide.md
+++ b/src/llms_guide.md
@@ -1,0 +1,209 @@
+# skem — LLM Usage Guide
+
+This document is the authoritative quick reference for an LLM agent
+that needs to drive the `skem` CLI. It is self-contained: an agent
+should be able to perform every common task from this text alone.
+
+`skem` is a lightweight CLI that downloads specific files or directories
+from remote Git repositories using sparse checkout, tracks their state
+in a lockfile, and runs hooks when downloaded files change.
+
+## Mental model
+
+- `.skem.yaml` declares dependencies: which repo, which paths inside it,
+  where to copy them, and which commands to run when they change.
+- `.skem.lock` records the commit SHA last synced for each dependency.
+  It is generated and updated by `skem` and should be committed to VCS.
+- `skem sync` reconciles the working tree with `.skem.yaml`, updating
+  files and `.skem.lock` and running hooks when something changed.
+- All other subcommands are conveniences around editing `.skem.yaml`,
+  inspecting state, or querying remotes.
+
+## Subcommands
+
+### `skem init`
+
+Create a `.skem.yaml` template in the current directory. Fails if the
+file already exists. Use this once at the start of a project.
+
+### `skem schema`
+
+Print the JSON Schema for `.skem.yaml` to stdout. Pipe this into an
+editor schema store or use it to validate a configuration file.
+
+### `skem sync`
+
+Reconcile every dependency in `.skem.yaml`:
+
+1. Resolve the remote commit SHA for each dependency's `rev`.
+2. Compare against `.skem.lock` to decide whether anything changed.
+3. For changed dependencies, sparse-checkout the configured `paths`
+   and copy them into `out`.
+4. Run that dependency's `hooks` (only when files actually changed).
+5. After all dependencies are processed, run top-level `post_hooks`.
+
+Flags:
+
+- `--force` — re-sync every dependency even when the lockfile already
+  matches the remote SHA. Use this when output files were modified
+  locally and you want to restore them.
+- `--hooks-only` — skip fetching, but still run `hooks` and
+  `post_hooks`. Useful when a hook command itself was edited and you
+  want to re-run it without touching the vendored files.
+
+`--force` and `--hooks-only` are mutually exclusive at runtime.
+
+### `skem add`
+
+Append a new dependency to `.skem.yaml`. Two modes:
+
+- **Interactive (recommended)**: omit `--paths` and `--out`. The CLI
+  clones the repo, lets the user browse the tree, and prompts for the
+  output directory.
+
+  ```
+  skem add --repo https://github.com/example/api.git
+  ```
+
+- **Full specification**: pass everything on the command line.
+
+  ```
+  skem add --repo https://github.com/example/api.git \
+           --paths proto/ openapi/ \
+           --out ./vendor/api \
+           --name my-api \
+           --rev v2.0
+  ```
+
+Flags:
+
+- `--repo <URL>` (required) — Git repository URL.
+- `--paths <PATH>...` — one or more paths to sparse-checkout.
+- `--out <DIR>` — output directory.
+- `--name <NAME>` — dependency name (defaults to the repo's basename).
+- `--rev <REV>` — branch, tag, or commit SHA (defaults to the remote
+  default branch).
+
+`--paths` and `--out` must be specified together, or both omitted to
+enter interactive mode.
+
+`skem add` only edits `.skem.yaml`; run `skem sync` afterwards to
+actually fetch the files.
+
+### `skem rm <name>`
+
+Remove the dependency named `<name>` from `.skem.yaml` and its entry
+from `.skem.lock`. Does not delete the previously vendored files in
+`out/`; remove them manually if desired.
+
+### `skem ls`
+
+List every dependency in `.skem.yaml` with its current sync status
+relative to `.skem.lock`.
+
+### `skem check`
+
+Query each dependency's remote and report whether it is ahead of the
+lockfile. Exits with code `0` when everything is up to date and code
+`1` when at least one dependency has updates available. Suitable for
+CI: run `skem check` to fail the build when the lockfile is stale.
+
+### `skem self-update`
+
+Update the `skem` binary itself to the latest release. Network access
+to GitHub is required.
+
+### `skem llms`
+
+Print this guide to stdout. Intended for LLM agents and for piping
+into agent context files.
+
+## Configuration file format (`.skem.yaml`)
+
+```yaml
+deps:
+  - name: example-api
+    repo: "https://github.com/example/api.git"
+    rev: "main"                 # optional; defaults to remote HEAD
+    paths:
+      - "proto/v1/"             # directory (trailing slash) or file
+      - "schemas/user.proto"    # individual files are supported
+    out: "./vendor/api"
+    hooks:
+      - "echo 'Files updated'"
+post_hooks:
+  - "echo 'All dependencies synced'"
+```
+
+### Fields
+
+| Field            | Required | Description                                                                  |
+| ---------------- | -------- | ---------------------------------------------------------------------------- |
+| `deps`           | yes      | List of dependencies.                                                        |
+| `deps[].name`    | yes      | Identifier; also used as the lockfile key.                                   |
+| `deps[].repo`    | yes      | Git repository URL (any URL `git` can clone).                                |
+| `deps[].rev`     | no       | Branch, tag, or commit SHA. Defaults to the remote's default branch (HEAD). |
+| `deps[].paths`   | yes      | List of paths inside the repo to fetch via sparse-checkout.                  |
+| `deps[].out`     | yes      | Local output directory; created if absent.                                   |
+| `deps[].hooks`   | no       | Commands run after that single dependency is synced (only on change).        |
+| `post_hooks`     | no       | Commands run once after all dependencies finish syncing.                     |
+
+### Path semantics
+
+- Paths ending with `/` are directories; their *contents* are copied
+  into `out`, preserving the directory's internal structure but
+  stripping the leading path prefix.
+- Paths without `/` may be files; the file is copied directly into
+  `out`.
+- Multiple `paths` entries are merged into the same `out` directory.
+
+### Hooks
+
+`hooks` and `post_hooks` are executed via the user's shell. They run
+in the project root (the directory containing `.skem.yaml`).
+
+Per-dependency `hooks` receive the following environment variable:
+
+- `SKEM_SYNCED_FILES` — space-separated list of file paths (under
+  `out`) that were written during the sync. Example:
+
+  ```yaml
+  hooks:
+    - "protoc --go_out=. $SKEM_SYNCED_FILES"
+  ```
+
+`post_hooks` do not receive `SKEM_SYNCED_FILES`.
+
+## Lockfile (`.skem.lock`)
+
+`.skem.lock` is YAML and looks like:
+
+```yaml
+locks:
+  - name: example-api
+    repo: "https://github.com/example/api.git"
+    rev: "main"
+    sha: "0123456789abcdef0123456789abcdef01234567"
+```
+
+Treat it as machine-managed: do not hand-edit it. Commit it to VCS so
+that other developers and CI get reproducible syncs.
+
+## Typical workflows for an agent
+
+- **First time in a repo without skem**:
+  `skem init` → edit `.skem.yaml` or use `skem add` → `skem sync`.
+- **Bumping a dependency to a new revision**: edit its `rev` in
+  `.skem.yaml`, then `skem sync`.
+- **Restoring vendored files after local edits**: `skem sync --force`.
+- **Re-running a hook after editing the hook command**:
+  `skem sync --hooks-only`.
+- **CI gate that vendored files are current**: `skem check` (non-zero
+  exit means the lockfile is behind a remote).
+- **Auditing the schema in an editor**: `skem schema > schema.json`
+  and point the editor at it.
+
+## Exit codes
+
+- `0` — success (and, for `skem check`, "everything up to date").
+- `1` — any error, or for `skem check`, "updates are available".

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use skem::{add, check, config, init, interactive, ls, rm, schema, self_update, sync};
+use skem::{add, check, config, init, interactive, llms, ls, rm, schema, self_update, sync};
 use std::path::Path;
 
 #[derive(Parser)]
@@ -54,6 +54,8 @@ enum Commands {
     Check,
     /// Update skem to the latest version
     SelfUpdate,
+    /// Print a self-contained English usage guide aimed at LLM agents
+    Llms,
 }
 
 fn main() {
@@ -97,6 +99,7 @@ fn main() {
             Err(e) => Err(e),
         },
         Commands::SelfUpdate => self_update::run_self_update(),
+        Commands::Llms => llms::run(),
     };
 
     if let Err(e) = result {
@@ -291,5 +294,11 @@ mod tests {
     fn test_self_update_command_parsing() {
         let cli = Cli::parse_from(vec!["skem", "self-update"]);
         assert!(matches!(cli.command, Commands::SelfUpdate));
+    }
+
+    #[test]
+    fn test_llms_command_parsing() {
+        let cli = Cli::parse_from(vec!["skem", "llms"]);
+        assert!(matches!(cli.command, Commands::Llms));
     }
 }


### PR DESCRIPTION
## Summary

- Adds a new `skem llms` subcommand that prints a self-contained English usage guide aimed at LLM agents (Claude Code, etc.).
- The guide (`src/llms_guide.md`, embedded via `include_str!`) covers the mental model, every subcommand, `.skem.yaml` / `.skem.lock` format, hook environment variables (`SKEM_SYNCED_FILES`), typical workflows, and exit-code semantics — designed so an agent can drive `skem` from a single invocation without reading the README or `docs/`.
- Typical usage: `skem llms > AGENTS.skem.md` and feed it into the agent's context.

## Test plan

- [x] `cargo test` — all tests pass, including new tests in `src/llms.rs` that assert the guide documents every subcommand, every config field, `SKEM_SYNCED_FILES`, `--force` / `--hooks-only`, interactive add mode, and `skem check` exit-code semantics.
- [x] `cargo clippy --all-targets --all-features` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo run -- llms` prints the guide; `cargo run -- --help` shows `llms` in the subcommand list.