### PR TITLE
fix: configure bin_path_in_archive for self-update

### DIFF
--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -15,6 +15,7 @@ pub fn run_self_update() -> Result<()> {
         .target(target)
         .current_version(current_version)
         .identifier(&format!("{BIN_NAME}-{target}.tar.gz"))
+        .bin_path_in_archive("{{ bin }}-{{ target }}/{{ bin }}")
         .build()?
         .update()?;
 
@@ -54,6 +55,7 @@ mod tests {
             .target(target)
             .current_version(current_version)
             .identifier(&format!("{BIN_NAME}-{target}.tar.gz"))
+            .bin_path_in_archive("{{ bin }}-{{ target }}/{{ bin }}")
             .build();
 
         assert!(


### PR DESCRIPTION
## Summary

`skem self-update` from v0.3.1 to v0.4.0 fails with:

```
Extracting archive... Error: UpdateError: Could not find the required path in the archive: "skem"
```

Release tarballs are packaged as `skem-<target>/skem` by `.github/workflows/build-and-publish.yaml` (`mkdir "${ARCHIVE_NAME}" && cp <bin> "${ARCHIVE_NAME}/"`), but the `self_update` crate defaults to looking for the binary at the archive root (just `skem`).

This PR tells `self_update` where the binary actually lives by setting `bin_path_in_archive("{{ bin }}-{{ target }}/{{ bin }}")`, matching the archive layout. The `{{ bin }}` / `{{ target }}` placeholders are part of the official `self_update` API (see `self_update-0.42.0/src/backends/gitea.rs` doc example).

### Heads-up

This only takes effect for releases that include the fix. The already-broken v0.3.1 -> v0.4.0 path cannot be repaired retroactively; affected users need to re-run the install script:

```
curl -fsSL https://raw.githubusercontent.com/hiro-o918/skem/main/install.sh | bash
```

## Test plan

- [x] `cargo test self_update` — both unit tests pass (incl. the builder-config test, now updated to include `bin_path_in_archive`).
- [x] `cargo clippy --all-targets --all-features` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] Verified locally that the v0.4.0 tarball really has `skem-aarch64-apple-darwin/skem` inside (`tar tzf` on the released asset).
- [ ] After release, run `skem self-update` from this version to the next and confirm it succeeds.